### PR TITLE
Utilisation API Géo et géométries simplifiées pour les départements

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -528,7 +528,7 @@ function onDepartementClick(event) {
 	});
 
 	// Chargement de la liste des départements
-	$.getJSON("donneesgeo/departements.json", 
+	$.getJSON("https://geo.api.gouv.fr/departements?fields=nom,code",
 		function (data) {
 			var $select = $('#departements');
 			$.each(data, function (i, val) {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -541,7 +541,7 @@ function onDepartementClick(event) {
 	);
 
 	// Chargement des contours des départements
-	$.getJSON("donneesgeo/departements-100m.geojson",
+	$.getJSON("donneesgeo/departements-1000m.geojson",
 		function (data) {
 			departements = data;
 			departements.features.forEach(function (state) {


### PR DESCRIPTION
Les géométries simplifiées à 1000 mètres permettent de diviser par 12 la taille du fichier des départements chargé initialement.
Cela accélère considérablement le démarrage de l'application sur smartphone.

Utilise aussi la liste des départements issue de l'API Géo, pour rester cohérent avec la liste des communes.