### PR TITLE
Suppression de la seule arrow function

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -329,7 +329,9 @@ function entrerDansSection(sonCode) {
 	).then(
 		// Une fois qu'on a la géographie et les mutations, on fait tout l'affichage
 		function () {
-			data_geo.features = data_geo.features.filter(e => (sonCode == (e.properties.prefixe + ('0'+ e.properties.section).slice(-2))));
+			data_geo.features = data_geo.features.filter(function(e) {
+				return (sonCode == (e.properties.prefixe + ('0'+ e.properties.section).slice(-2)))
+			});
 			if (parcellesLayer != null) {
 				map.removeLayer(parcellesLayer);
 			}


### PR DESCRIPTION
Cette syntaxe très pratique n'est utilisée qu'à un seul endroit et sans transpilation, il apparait donc plus cohérent de la supprimer étant donné que cela réduit la compatibilité avec certains navigateurs.