### PR TITLE
Marqueurs sections rendus non interactifs

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -179,6 +179,7 @@ function onEachFeatureCommune(feature, layer) {
 function onEachFeatureSection(feature, layer) {
 
 	var label = L.marker(layer.getBounds().getCenter(), {
+			interactive: false,
 			icon: L.divIcon({
 				className: 'labelSection',
 				html: (feature.properties.prefixe + feature.properties.code).replace(/^0+/, ''),


### PR DESCRIPTION
pour propager les événements aux vecteurs car on a tendance à cliquer sur le libellé sans qu'il ne se passe rien.