### PR TITLE
Tri des communes par ordre alphabétique

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -397,6 +397,11 @@ function entrerDansCommune(sonCode) {
 			if (sectionsLayer != null) {
 				map.removeLayer(sectionsLayer);
 			}
+
+			data.features.sort(function (a, b) {
+				if (!a.properties.nom) return -Infinity;
+				return a.properties.nom.localeCompare(b.properties.nom);
+			});
 			sectionsLayer = L.geoJson(data, {
 					weight: 1,
 					fillOpacity: 0.2,


### PR DESCRIPTION
L'API Geo renvoie un certain ordre, mais qui n'est pas du tout pratique pour trouver la commune souhaitée.

Le tri par ordre alphabétique pour l'affichage des communes semble beaucoup plus naturel.