### PR TITLE
Calcule les mutations à la parcelle dans le navigateur

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,6 +14,7 @@
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
 		<script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
 		<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
+		<script type="text/javascript" src="https://unpkg.com/lodash@4.17.11/lodash.min.js"></script>
 		<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
 		<link rel="shortcut icon" type="image/x-icon" href="/favicon.png">
 	</head>


### PR DESCRIPTION
Avant cette PR, l'application JS fait appel à la route `/api/parcelles`, qui est, compte-tenu de la charge actuelle, consommatrice de ressources et difficile à mettre en cache.

Cette implémentation dans le navigateur s'appuie sur les données à la section déjà récupérées.

La seule différence est que cette implémentation ne permet pas de détecter les mutations liées sur des parcelles en dehors de la section.