### PR TITLE
Menu avec défilement

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,7 +1,7 @@
 html, body {
 	color: #fff;
 	font-size: 14px !important;
-	height: 100%;
+	height: 100vh;
 }
 
 th {
@@ -13,13 +13,13 @@ th {
 }
 
 .wrapper {
-    width: 100%;
-    min-height: calc(100vh - 49px);
+  width: 100%;
+  height: calc(100vh - 49px);
 	display: flex;
 }
 
 #content {
-	min-height: 100%;
+	height: 100%;
 	width: 100%;
 }
 
@@ -27,14 +27,14 @@ th {
     min-width: 250px;
     max-width: 250px;
 	background-color: #212D32;
-	min-height: 100%;
+	height: 100%;
 }
 
 #sidebar_right {
   min-width: 250px;
   max-width: 250px;
 	background-color: #212D32;
-	min-height: 100%;
+	height: 100%;
 }
 
 .scrollable {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -14,7 +14,7 @@ th {
 
 .wrapper {
   width: 100%;
-  height: calc(100vh - 49px);
+  height: calc(100vh - 48px);
 	display: flex;
 }
 
@@ -38,7 +38,6 @@ th {
 }
 
 .scrollable {
-  height: 95vh;
   overflow-y: scroll;
 }
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -31,14 +31,19 @@ th {
 }
 
 #sidebar_right {
-    min-width: 250px;
-    max-width: 250px;
+  min-width: 250px;
+  max-width: 250px;
 	background-color: #212D32;
 	min-height: 100%;
 }
 
-#mapid { 
-	height: 100%; 
+.scrollable {
+  height: 95vh;
+  overflow-y: scroll;
+}
+
+#mapid {
+	height: 100%;
 }
 
 .labelFeuille {

--- a/static/index.html
+++ b/static/index.html
@@ -32,7 +32,7 @@
 			</div>
 		</div>
 		<div id="app" class="wrapper">
-			<div id="sidebar_left" v-show="!fold_left" class="container">
+			<div id="sidebar_left" v-show="!fold_left" class="container scrollable">
 				<br/>
 				<div class="form-group">
 					<label for="departements" class="control-label">Département</label>
@@ -76,7 +76,7 @@
 			<div id="content">
 				<div id="mapid"></div>
 			</div>
-			<div id="sidebar_right" class="container" v-if="parcelle != null && parcelle.mutations.length > 0">
+			<div id="sidebar_right" class="container scrollable" v-if="parcelle != null && parcelle.mutations.length > 0">
 				<span onclick="sortirDeParcelle()" class="mt-2 mb-2 close-link">Fermer</span>
 				<br/>
 				<boite-accordeon  v-for="(mutation, index) in parcelle.mutations" :mutation="mutation" :key="mutation.infos[0]['Code parcelle'] + index" :index="index"></boite-accordeon>


### PR DESCRIPTION
Permet de faire défiler la liste des informations des menus dépliants.
Ce comportement a pour effet de corriger un problème de comportement de la carte causé par le `overflow` de menu de droite.