### PR TITLE
Corrige l'affichage inutile des barres de défilement sur certaines navigateurs/OS

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,7 +1,8 @@
 html, body {
 	color: #fff;
 	font-size: 14px !important;
-	height: 100vh;
+  height: 100vh;
+  overflow-y: hidden;
 }
 
 th {
@@ -34,7 +35,7 @@ th {
 }
 
 .scrollable {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 #mapid {


### PR DESCRIPTION
Testé avec Windows 7 / Chrome sous [browserling](http://browserling.com).

Fix #40